### PR TITLE
fix(android): missing `hasConstants` boolean on ReactModuleInfo

### DIFF
--- a/android/src/main/java/com/zoontek/rnedgetoedge/EdgeToEdgePackage.kt
+++ b/android/src/main/java/com/zoontek/rnedgetoedge/EdgeToEdgePackage.kt
@@ -21,6 +21,7 @@ class EdgeToEdgePackage : BaseReactPackage() {
         EdgeToEdgeModuleImpl.NAME,
         canOverrideExistingModule = false,
         needsEagerInit = true,
+        hasConstants = true,
         isCxxModule = false,
         isTurboModule = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
       )


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Android is not building from `1.3.0` 

Error : 

```
None of the following functions can be called with the arguments supplied:
public constructor ReactModuleInfo(_name: String, _className: String, _canOverrideExistingModule: Boolean, _needsEagerInit: Boolean, isCxxModule: Boolean, isTurboModule: Boolean)
```

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to test it (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I added a sample use of the API in the example project (`example/src/App.tsx`)
