### PR TITLE
Fixes showing Status Bar when launched with hidden status bar

### DIFF
--- a/src/SystemBars.ts
+++ b/src/SystemBars.ts
@@ -36,8 +36,8 @@ function mergeEntriesStack(entriesStack: SystemBarsEntry[]) {
   return entriesStack.reduce<{
     statusBarStyle: SystemBarStyle | undefined;
     navigationBarStyle: SystemBarStyle | undefined;
-    statusBarHidden: boolean;
-    navigationBarHidden: boolean;
+    statusBarHidden: boolean | undefined;
+    navigationBarHidden: boolean | undefined;
   }>(
     (prev, cur) => {
       for (const prop in cur) {
@@ -51,8 +51,8 @@ function mergeEntriesStack(entriesStack: SystemBarsEntry[]) {
     {
       statusBarStyle: undefined,
       navigationBarStyle: undefined,
-      statusBarHidden: false,
-      navigationBarHidden: false,
+      statusBarHidden: undefined,
+      navigationBarHidden: undefined,
     },
   );
 }
@@ -85,13 +85,13 @@ let updateImmediate: NodeJS.Immediate | null = null;
 const currentValues: {
   statusBarStyle: ResolvedBarStyle;
   navigationBarStyle: ResolvedBarStyle;
-  statusBarHidden: boolean;
-  navigationBarHidden: boolean;
+  statusBarHidden: boolean | undefined;
+  navigationBarHidden: boolean | undefined;
 } = {
   statusBarStyle: undefined,
   navigationBarStyle: undefined,
-  statusBarHidden: false,
-  navigationBarHidden: false,
+  statusBarHidden: undefined,
+  navigationBarHidden: undefined,
 };
 
 function setStatusBarStyle(style: ResolvedBarStyle) {


### PR DESCRIPTION
# Summary

Hi
If we launch app with status bar hidden and try to show it won't since in the lib initial state for values is "false" ("already showed" - and it's not)

https://github.com/zoontek/react-native-edge-to-edge/blob/main/src/SystemBars.ts#L123